### PR TITLE
Restructure project section and update featured projects data

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -47,12 +47,16 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <div className="absolute top-4 right-4">
-            <HomeButton /> 
-            <ThemeToggle />
 
+              <div className="flex items-center justify-end mx-2 gap-2">
+                <HomeButton /> 
+                <ThemeToggle />
+              </div>
+
+
+          <div className="flex-1">
+            {children}
           </div>
-          {children}
         </ThemeProvider>
 
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,8 +20,9 @@ export default function Home() {
             Amodh Herath // Engineering Ledger
           </h1>
           <p className="text-muted-foreground text-base max-w-2xl leading-relaxed">
-            Software Engineer bridging the gap between backend architecture and AI infrastructure. 
-            I spend my time building scalable data pipelines, event-driven microservices, and reliable operational tooling.
+            I write backend software focused on distributed architecture and system reliability. 
+            Instead of just wrapping APIs, I build the middleware that makes AI integration viable in production—handling the network edge, managing asynchronous events, and ensuring services communicate reliably without dropping data. I care about fault tolerance, concurrency, 
+            and engineering clean backend logic that stays fast under real-world load.
           </p>
         </div>
       </header>

--- a/app/projects/[project_id]/page.tsx
+++ b/app/projects/[project_id]/page.tsx
@@ -6,11 +6,49 @@ import { ArrowLeft, ExternalLink } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { GithubIcon } from "@/components/logo/logo";
-import { getProjectBySlug, projects } from "@/data/projects";
+import { getProjectBySlug, ProjectRecord, projects } from "@/data/projects";
 import { cn } from "@/lib/utils";
 
 export async function generateStaticParams() {
   return projects.map((project) => ({ project_id: project.slug }));
+}
+
+// Component to display the articles , if there are any otherwise a simple text is displayed
+function Articles({ relatedArticles }: { relatedArticles: ProjectRecord["relatedArticles"] }) {
+  if (relatedArticles.length === 0 ) {
+    return <h3 className="text-muted">Articles are ongoing...</h3>;
+  } 
+
+  return relatedArticles.map((article) => (
+      <Link
+        key={article.id}
+        href={article.href}
+        target="_blank"
+        rel="noreferrer"
+        className="group block rounded-lg border border-border bg-card p-4 hover:bg-accent/60 transition-colors"
+      >
+        <article className="flex flex-col gap-4 sm:flex-row sm:items-start">
+          <div className="w-full sm:w-56 shrink-0 overflow-hidden rounded-md border border-border">
+            <Image
+              src={article.thumbnail}
+              alt={article.title}
+              width={640}
+              height={360}
+              className="h-auto w-full"
+            />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[10px] uppercase tracking-widest text-muted-foreground mb-2">{article.source}</p>
+            <h3 className="text-base font-semibold mb-2 group-hover:text-primary transition-colors">{article.title}</h3>
+            <p className="text-sm text-muted-foreground leading-relaxed">{article.summary}</p>
+            <p className="text-xs mt-3 inline-flex items-center gap-1 text-primary">
+              Open article <ExternalLink className="h-3.5 w-3.5" />
+            </p>
+          </div>
+        </article>
+      </Link>
+    ));
+  
 }
 
 export default async function ProjectDetailsPage({
@@ -59,7 +97,7 @@ export default async function ProjectDetailsPage({
       </header>
 
       <section className="mb-12">
-        <h2 className="uppercase tracking-widest text-muted-foreground font-semibold mb-5 text-xs">Architecture</h2>
+        <h2 className="uppercase tracking-widest text-muted-foreground font-semibold mb-5 text-xl">Architecture</h2>
         <div className="overflow-hidden rounded-lg border border-border bg-card">
           <Image
             src={project.architectureImage}
@@ -73,7 +111,7 @@ export default async function ProjectDetailsPage({
       </section>
 
       <section className="mb-12">
-        <h2 className="uppercase tracking-widest text-muted-foreground font-semibold mb-5 text-xs">Project Snapshot</h2>
+        <h2 className="uppercase tracking-widest text-muted-foreground font-semibold mb-5 text-xl">Project Snapshot</h2>
         <div className="grid gap-3 text-sm border border-border rounded-lg p-5 bg-card">
           <p>
             <span className="text-muted-foreground uppercase tracking-wider text-xs">Role</span>
@@ -89,37 +127,9 @@ export default async function ProjectDetailsPage({
       </section>
 
       <section>
-        <h2 className="uppercase tracking-widest text-muted-foreground font-semibold mb-5 text-xs">Related Articles</h2>
+        <h2 className="uppercase tracking-widest text-muted-foreground font-semibold mb-5 text-xl">Related Articles</h2>
         <div className="space-y-4">
-          {project.relatedArticles.map((article) => (
-            <Link
-              key={article.id}
-              href={article.href}
-              target="_blank"
-              rel="noreferrer"
-              className="group block rounded-lg border border-border bg-card p-4 hover:bg-accent/60 transition-colors"
-            >
-              <article className="flex flex-col gap-4 sm:flex-row sm:items-start">
-                <div className="w-full sm:w-56 shrink-0 overflow-hidden rounded-md border border-border">
-                  <Image
-                    src={article.thumbnail}
-                    alt={article.title}
-                    width={640}
-                    height={360}
-                    className="h-auto w-full"
-                  />
-                </div>
-                <div className="min-w-0">
-                  <p className="text-[10px] uppercase tracking-widest text-muted-foreground mb-2">{article.source}</p>
-                  <h3 className="text-base font-semibold mb-2 group-hover:text-primary transition-colors">{article.title}</h3>
-                  <p className="text-sm text-muted-foreground leading-relaxed">{article.summary}</p>
-                  <p className="text-xs mt-3 inline-flex items-center gap-1 text-primary">
-                    Open article <ExternalLink className="h-3.5 w-3.5" />
-                  </p>
-                </div>
-              </article>
-            </Link>
-          ))}
+          <Articles relatedArticles={project.relatedArticles} />
         </div>
       </section>
     </main>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+// Projects Page which contains all the projects and their portals to 
+
+
 // app/projects/page.tsx
 import { useMemo, useState } from "react";
 import Link from "next/link";
@@ -8,13 +11,14 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/com
 import { buttonVariants } from "@/components/ui/button";
 import { GithubIcon } from "@/components/logo/logo";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { projects } from "@/data/projects";
+import { getFeaturedProjects, ProjectRecord, projects } from "@/data/projects";
 import { cn } from "@/lib/utils";
 
 export default function ProjectsIndexPage() {
   const [query, setQuery] = useState("");
 
-  const featuredProjects = projects.slice(0, 3);
+  // featured projects Cards
+  const featuredProjects : ProjectRecord[] = getFeaturedProjects();
 
   const filteredProjects = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
@@ -56,6 +60,7 @@ export default function ProjectsIndexPage() {
         </div>
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {featuredProjects.map((project) => (
+
             <Card key={project.id} className="group h-full border-border bg-card hover:border-primary hover:bg-accent/50 transition-all duration-200 flex flex-col relative overflow-hidden">
               <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-border to-transparent group-hover:from-primary transition-colors" />
 

--- a/components/portfolio/active-systems.tsx
+++ b/components/portfolio/active-systems.tsx
@@ -5,9 +5,10 @@ import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import type { ProjectRecord } from "@/data/projects"
+import { getFeaturedProjects,ProjectRecord } from "@/data/projects"
 
 export function FeaturedProjects({ projects }: { projects: ProjectRecord[] }) {
+  const featuredProjects = getFeaturedProjects();
   return (
     <section className="mb-20">
       <div className="mb-6 flex items-center justify-between gap-4 ">
@@ -32,7 +33,7 @@ export function FeaturedProjects({ projects }: { projects: ProjectRecord[] }) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {projects.map((project) => (
+              {featuredProjects.map((project) => (
                 <TableRow key={project.id}>
                   <TableCell className="font-medium align-top pt-4">{project.id}</TableCell>
                   <TableCell className="align-top pt-4 whitespace-normal">

--- a/data/data.ts
+++ b/data/data.ts
@@ -40,7 +40,7 @@ export const academics: Academic[] = [
     credential: "B.Sc. Computer Engineering",
     period: "Expected 2026",
     details: [
-      "Specialization tracks: Distributed Systems, Software Architecture",
+      "Specialization tracks: Artificial Intelligence, Software Architecture, Machine Learning, Embedded Systems",
       "Core focus on backend infrastructure and AI optimization"
     ]
   },
@@ -65,24 +65,25 @@ export const academics: Academic[] = [
 ];
 
 export const publications: Publication[] = [
-  {
-    type: "IEEE Extended Abstract",
-    title: "Emotion Recognition of Sinhala Language Texts in Social Media",
-    description: "Fine-tuned SinBERT models to classify complex linguistic sentiment and emotional markers in localized data streams. Focus on NLP and model optimization.",
-    status: "Authored"
-  },
+  // {
+  //   type: "IEEE Extended Abstract",
+  //   title: "Emotion Recognition of Sinhala Language Texts in Social Media",
+  //   description: "Fine-tuned SinBERT models to classify complex linguistic sentiment and emotional markers in localized data streams. Focus on NLP and model optimization.",
+  //   status: "Authored"
+  // },
   {
     type: "Technical Broadcasting",
-    title: "System Architecture & Career Optimization",
-    description: "Producing technical video content focused on system design patterns, distributed architecture tutorials, and career strategies for a global developer audience.",
-    status: "Active (YouTube)"
+    title: "Docling and SLM",
+    description: "Buiding a robust data extraction pipeline with Docling and a Small Language Model",
+    status: "Under review(Medium)"
   }
 ];
 
 export const infrastructureMatrix = {
-  "Languages": "Go, Java, Python, TypeScript",
+  "Languages": "C++, Go, Java, Python, TypeScript",
   "Orchestration & State": "Apache Kafka, Temporal.io, Docker",
   "Monitoring & Telemetry": "Prometheus",
-  "Frameworks & UI": "Spring Boot, Next.js, Tailwind CSS",
-  "AI / ML Ops": "SinBERT, SLM Integration, LLM Security"
+  "Frameworks & UI": "Spring Boot, Next.js, Tailwind CSS, FastAPI, React",
+  "AI / ML ": "Pytorch, Scikit-learn ",
+  "Cloud":"AWS, Oracle(OCI)"
 };

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -22,42 +22,95 @@ export interface ProjectRecord {
   relatedArticles: RelatedArticle[];
 }
 
+export function getProjectBySlug(projectId: string) {
+  return projects.find((project) => project.slug === projectId);
+}
+
 export const projects: ProjectRecord[] = [
   {
     id: "SYS-01",
-    slug: "janus-security-gateway",
-    name: "Janus Security Gateway",
-    githubUrl: "https://github.com/amodhherath/janus-security-gateway",
+    slug: "janus",
+    name: "Janus",
+    githubUrl: "https://github.com/amodhyh/Janus",
     status: "Ongoing",
-    role: "LLM Security Gateway",
-    stack: "Go, Python, Docker",
+    role: "Security Model Service",
+    stack: "Go, Docker",
     shortDescription:
-      "Edge proxy that sanitizes prompts, detects prompt injection, and redacts sensitive entities before model execution.",
+      "Command-line security gateway with modular security model services, configuration management, and Docker Compose deployment.",
     description:
-      "Janus is an edge-deployed gateway for high-risk AI workloads. Incoming prompts are routed through policy checks, injection detection pipelines, and PII redaction workers. The service is designed around low-latency request handling so production model endpoints can be protected without disrupting user experience.",
+      "Janus is a lightweight Go-based security tool designed for command-line operations and model-driven protection layers. It includes dedicated services for security modeling, configuration handling, and containerized deployment via Docker Compose. The architecture supports low-overhead security checks and modular components, making it suitable for protecting CLI workflows or early-stage gateway scenarios in production environments.",
     architectureImage: "/projects/architecture/janus.svg",
-    architectureAlt: "Janus architecture with API gateway, policy engine, and model sidecars",
+    architectureAlt: "Janus architecture showing cmd/janus entrypoint, config layer, and security model service",
     relatedArticles: [
       {
         id: "janus-art-1",
-        title: "Prompt Injection Defense Patterns in Production",
-        source: "Medium",
-        href: "https://medium.com/",
-        summary: "Breakdown of layered prompt defenses and runtime policy gates for enterprise LLM workloads.",
-        thumbnail: "/projects/articles/prompt-defense.svg"
+        title: "Building Modular Security Models in Go",
+        source: "Dev.to",
+        href: "https://dev.to/",
+        summary: "Practical patterns for command-line security tools using Go modules and service isolation.",
+        thumbnail: "/projects/articles/go-security-model.svg"
       },
       {
         id: "janus-art-2",
-        title: "PII Redaction with Small Language Models",
-        source: "Dev.to",
-        href: "https://dev.to/",
-        summary: "How lightweight local models can perform reliable redaction with predictable latency.",
-        thumbnail: "/projects/articles/pii-redaction.svg"
+        title: "Docker Compose for Security Tooling",
+        source: "Medium",
+        href: "https://medium.com/",
+        summary: "How to containerize Go-based security services for consistent development and deployment.",
+        thumbnail: "/projects/articles/docker-security.svg"
       }
     ]
   },
   {
     id: "SYS-02",
+    slug: "sazzler-core",
+    name: "Sazzler Core",
+    githubUrl: "https://github.com/amodhyh/sazzler-core",
+    status: "Ongoing",
+    role: "Event-Driven Commerce Platform",
+    stack: "Java, Spring Boot, Kafka",
+    shortDescription:
+      "Microservices-based e-commerce backend built on event-sourcing principles and async choreographies.",
+    description:
+      "Sazzler operates as a heavy-lifting microservices platform handling core commerce domains. It relies on Kafka for asynchronous communication between inventory, ordering, and payment services. The architecture heavily emphasizes idempotent consumers, strict domain boundaries, and eventual consistency to maintain high throughput and reliability under load.",
+    architectureImage: "/projects/architecture/sazzler.svg",
+    architectureAlt: "Sazzler microservices topology communicating via Kafka event backbone",
+    relatedArticles: [
+      {
+        id: "sazzler-art-1",
+        title: "Event-Driven Choreography in Spring Boot",
+        source: "Medium",
+        href: "https://medium.com/",
+        summary: "Managing distributed transactions and eventual consistency without two-phase commit.",
+        thumbnail: "/projects/articles/commerce-events.svg"
+      },
+      {
+        id: "sazzler-art-2",
+        title: "Designing Idempotent Kafka Consumers",
+        source: "Dev.to",
+        href: "https://dev.to/",
+        summary: "Practical implementation of deduplication keys and retry logic in Java.",
+        thumbnail: "/projects/articles/kafka-idempotency.svg"
+      }
+    ]
+  },
+  {
+    id: "SYS-03",
+    slug: "developer-portfolio",
+    name: "Engineering Portfolio",
+    githubUrl: "https://github.com/amodhyh/portfolio",
+    status: "Production",
+    role: "Frontend Engineering",
+    stack: "Next.js, TypeScript, Vercel",
+    shortDescription:
+      "Static site engineered to showcase backend architecture, system design case studies, and engineering maturity.",
+    description:
+      "A high-performance portfolio built with strict TypeScript and Next.js. It focuses on clean UI layout and fast content delivery for technical case studies. The repository demonstrates modern frontend best practices, component reusability, and automated deployment pipelines.",
+    architectureImage: "/projects/architecture/portfolio.svg",
+    architectureAlt: "Next.js static site generation pipeline",
+    relatedArticles: []
+  },
+  {
+    id: "SYS-04",
     slug: "centurion-aiops",
     name: "Centurion AIOps",
     githubUrl: "https://github.com/amodhherath/centurion-aiops",
@@ -89,41 +142,4 @@ export const projects: ProjectRecord[] = [
       }
     ]
   },
-  {
-    id: "SYS-03",
-    slug: "sazzler-core",
-    name: "Sazzler Core",
-    githubUrl: "https://github.com/amodhherath/sazzler-core",
-    status: "Production",
-    role: "Event-Driven Commerce Platform",
-    stack: "Java, Spring Boot, Kafka",
-    shortDescription:
-      "Microservice platform for order lifecycle management with event sourcing and async transaction choreography.",
-    description:
-      "Sazzler Core powers the backend of a commerce system where inventory, payments, and fulfillment are coordinated through Kafka events. Services are isolated by domain, contracts are versioned, and idempotent consumers ensure eventual consistency under high-throughput load.",
-    architectureImage: "/projects/architecture/sazzler.svg",
-    architectureAlt: "Sazzler architecture with domain services connected over Kafka",
-    relatedArticles: [
-      {
-        id: "sazzler-art-1",
-        title: "Transactional Boundaries in Event-Driven Commerce",
-        source: "Medium",
-        href: "https://medium.com/",
-        summary: "A practical look at choreography-based flows and failure handling in order pipelines.",
-        thumbnail: "/projects/articles/commerce-events.svg"
-      },
-      {
-        id: "sazzler-art-2",
-        title: "Idempotency Strategies for Kafka Consumers",
-        source: "Dev.to",
-        href: "https://dev.to/",
-        summary: "Patterns for dedupe keys, replay-safe processors, and consistency guarantees.",
-        thumbnail: "/projects/articles/kafka-idempotency.svg"
-      }
-    ]
-  }
 ];
-
-export function getProjectBySlug(projectId: string) {
-  return projects.find((project) => project.slug === projectId);
-}

--- a/data/projects.ts
+++ b/data/projects.ts
@@ -8,138 +8,140 @@ export interface RelatedArticle {
 }
 
 export interface ProjectRecord {
-  id: string;
+  id: string ;
   slug: string;
   name: string;
   githubUrl: string;
-  status: "Ongoing" | "Production" | "Research";
+  status: "Ongoing" | "Production" | "Upcoming" | "Completed";
   role: string;
   stack: string;
   shortDescription: string;
   description: string;
   architectureImage: string;
   architectureAlt: string;
-  relatedArticles: RelatedArticle[];
+  relatedArticles: RelatedArticle[] ;
 }
 
-export function getProjectBySlug(projectId: string) {
+
+
+// Featured Projects displayed int the cards
+const featured_projects = ["sazzler", "janus", "centurion"] as const;
+
+
+
+
+
+export function getProjectBySlug(projectId: string): ProjectRecord | undefined {
   return projects.find((project) => project.slug === projectId);
+}
+// get the featured project's ProjectRecord
+export function getFeaturedProjects(): ProjectRecord[] {
+  return featured_projects
+    .map((projectName) => getProjectBySlug(projectName))
+    .filter((project): project is ProjectRecord => project !== undefined);
 }
 
 export const projects: ProjectRecord[] = [
   {
     id: "SYS-01",
     slug: "janus",
-    name: "Janus",
+    name: "Janus Security Gateway",
     githubUrl: "https://github.com/amodhyh/Janus",
     status: "Ongoing",
-    role: "Security Model Service",
-    stack: "Go, Docker",
+    role: "Systems Architect",
+    stack: "Go, Python, gRPC, Redis, Docker",
     shortDescription:
-      "Command-line security gateway with modular security model services, configuration management, and Docker Compose deployment.",
+      "An ultra-low latency AI API gateway and reverse proxy featuring asynchronous prompt injection defense, PII redaction, and automated LLM fallback routing.",
     description:
-      "Janus is a lightweight Go-based security tool designed for command-line operations and model-driven protection layers. It includes dedicated services for security modeling, configuration handling, and containerized deployment via Docker Compose. The architecture supports low-overhead security checks and modular components, making it suitable for protecting CLI workflows or early-stage gateway scenarios in production environments.",
+      `Janus is an enterprise-grade AI edge proxy designed to secure, route, and audit LLM traffic. Built in Go for 
+      sub-millisecond network I/O, it implements a polyglot architecture utilizing gRPC to communicate with a 
+      dedicated Python sidecar for asynchronous Small Language Model (SLM) security inference. The system prioritizes architectural
+       resilience and zero-trust governance. Core capabilities include a Redis-backed Token Bucket algorithm for 
+       distributed rate limiting, declarative YAML configuration for seamless provider failovers (Circuit Breaker pattern), 
+       and out-of-band malicious payload interception to prevent token burn. By isolating the inference engine from the core 
+       reverse proxy, Janus provides strict data sovereignty and prompt injection defense without sacrificing the 
+       Time-To-First-Token (TTFT) performance critical to production AI applications.`,
     architectureImage: "/projects/architecture/janus.svg",
-    architectureAlt: "Janus architecture showing cmd/janus entrypoint, config layer, and security model service",
-    relatedArticles: [
-      {
-        id: "janus-art-1",
-        title: "Building Modular Security Models in Go",
-        source: "Dev.to",
-        href: "https://dev.to/",
-        summary: "Practical patterns for command-line security tools using Go modules and service isolation.",
-        thumbnail: "/projects/articles/go-security-model.svg"
-      },
-      {
-        id: "janus-art-2",
-        title: "Docker Compose for Security Tooling",
-        source: "Medium",
-        href: "https://medium.com/",
-        summary: "How to containerize Go-based security services for consistent development and deployment.",
-        thumbnail: "/projects/articles/docker-security.svg"
-      }
-    ]
+    architectureAlt: "Event-driven architecture diagram showing the Go control plane, Redis data plane, and the Python gRPC inspection layer.",
+    relatedArticles: []
   },
   {
     id: "SYS-02",
-    slug: "sazzler-core",
-    name: "Sazzler Core",
-    githubUrl: "https://github.com/amodhyh/sazzler-core",
+    slug: "sazzler",
+    name: "Sazzler",
+    githubUrl: "https://github.com/amodhyh/Project-Sazzler",
     status: "Ongoing",
     role: "Event-Driven Commerce Platform",
     stack: "Java, Spring Boot, Kafka",
     shortDescription:
       "Microservices-based e-commerce backend built on event-sourcing principles and async choreographies.",
     description:
-      "Sazzler operates as a heavy-lifting microservices platform handling core commerce domains. It relies on Kafka for asynchronous communication between inventory, ordering, and payment services. The architecture heavily emphasizes idempotent consumers, strict domain boundaries, and eventual consistency to maintain high throughput and reliability under load.",
+      `Sazzler operates as a heavy-lifting microservices platform handling core commerce domains. 
+      It relies on Kafka for asynchronous communication between inventory, ordering, and payment services. 
+      The architecture heavily emphasizes idempotent consumers, strict domain boundaries, and eventual 
+      consistency to maintain high throughput and reliability under load.`,
     architectureImage: "/projects/architecture/sazzler.svg",
     architectureAlt: "Sazzler microservices topology communicating via Kafka event backbone",
     relatedArticles: [
-      {
-        id: "sazzler-art-1",
-        title: "Event-Driven Choreography in Spring Boot",
-        source: "Medium",
-        href: "https://medium.com/",
-        summary: "Managing distributed transactions and eventual consistency without two-phase commit.",
-        thumbnail: "/projects/articles/commerce-events.svg"
-      },
-      {
-        id: "sazzler-art-2",
-        title: "Designing Idempotent Kafka Consumers",
-        source: "Dev.to",
-        href: "https://dev.to/",
-        summary: "Practical implementation of deduplication keys and retry logic in Java.",
-        thumbnail: "/projects/articles/kafka-idempotency.svg"
-      }
+      
     ]
   },
   {
     id: "SYS-03",
     slug: "developer-portfolio",
-    name: "Engineering Portfolio",
+    name: "Portfolio",
     githubUrl: "https://github.com/amodhyh/portfolio",
     status: "Production",
     role: "Frontend Engineering",
     stack: "Next.js, TypeScript, Vercel",
     shortDescription:
       "Static site engineered to showcase backend architecture, system design case studies, and engineering maturity.",
-    description:
-      "A high-performance portfolio built with strict TypeScript and Next.js. It focuses on clean UI layout and fast content delivery for technical case studies. The repository demonstrates modern frontend best practices, component reusability, and automated deployment pipelines.",
+    description: `A high-performance portfolio built with strict TypeScript and Next.js. 
+    It focuses on clean UI layout and fast content delivery for technical case studies. 
+    The repository demonstrates modern frontend best practices, componentreusability, and automated deployment pipelines.`,
     architectureImage: "/projects/architecture/portfolio.svg",
     architectureAlt: "Next.js static site generation pipeline",
     relatedArticles: []
   },
   {
     id: "SYS-04",
-    slug: "centurion-aiops",
+    slug: "centurion",
     name: "Centurion AIOps",
-    githubUrl: "https://github.com/amodhherath/centurion-aiops",
-    status: "Ongoing",
+    githubUrl: "https://github.com/amodhyh/centurion-aiops",
+    status: "Upcoming",
     role: "Autonomous SRE Agent",
     stack: "Go, Temporal, Prometheus",
     shortDescription:
       "Workflow-driven operations agent for incident triage, rollback orchestration, and self-healing execution.",
     description:
-      "Centurion automates operational response to telemetry anomalies. It consumes alerts, evaluates runbook strategies, and executes remediations through Temporal workflows. The architecture prioritizes observability, deterministic retries, and controlled escalation paths to human operators.",
+      `Centurion automates operational response to telemetry anomalies. 
+      It consumes alerts, evaluates runbook strategies, and executes remediations through Temporal workflows. 
+      The architecture prioritizes observability, deterministic retries, and controlled escalation paths to human operators.`,
     architectureImage: "/projects/architecture/centurion.svg",
     architectureAlt: "Centurion architecture with telemetry ingestion and Temporal orchestration",
     relatedArticles: [
-      {
-        id: "centurion-art-1",
-        title: "Designing Deterministic Incident Workflows",
-        source: "Hashnode",
-        href: "https://hashnode.com/",
-        summary: "An opinionated guide for reliable recovery pipelines using workflow engines.",
-        thumbnail: "/projects/articles/incident-workflows.svg"
-      },
-      {
-        id: "centurion-art-2",
-        title: "From Alert Fatigue to Actionable Signals",
-        source: "Substack",
-        href: "https://substack.com/",
-        summary: "Techniques for reducing noise and improving SRE response quality using telemetry contracts.",
-        thumbnail: "/projects/articles/alert-fatigue.svg"
-      }
+      
     ]
   },
+  
+  {
+  id: "SYS-05",
+  slug: "sortify",
+  name: "Sortify",
+  githubUrl: "https://github.com/amodhyh/Sortify",
+  status: "Completed",
+  role: "Fullstack AI Garbage Classifier",
+  stack: "React, FastAPI, Pytorch",
+  shortDescription:
+    "A full-stack AI application that processes and classifies waste materials using a custom machine learning model.",
+  description:
+    `Sortify addresses waste management inefficiencies through
+     automated image classification. A custom finetuned PyTorch CNN model is served via a FastAPI backend, 
+     exposing endpoints for low-latency image inference. The React frontend consumes these APIs to provide users 
+     with real-time feedback on garbage categorization, facilitating accurate recycling and disposal routin for 12 types 
+     of garbage Classes.`,
+  architectureImage: "/projects/architecture/sortify.svg",
+  architectureAlt: "Sortify architecture highlighting a React frontend communicating with a FastAPI and PyTorch inference server",
+  relatedArticles: []
+},
 ];


### PR DESCRIPTION
**PR title**
feat(projects): centralize featured projects + refresh project data

**PR description**
This PR centralizes “featured projects” selection and refreshes the projects dataset for the portfolio UI.

**What changed**
- Add `getFeaturedProjects()` (single source of truth for featured cards/table)
- Update the Projects index page and Featured Projects table to use the helper
- Refresh project metadata (slugs/status enum, descriptions) and add the Sortify project
- Modularised the article section, which now a proper empty state message
- Updated the description of the hero (about me) section.

**Notes / risk**
- `ProjectRecord.status` now includes additional values (e.g. `Upcoming`, `Completed`)—any UI that assumes the old union may need a quick check.
