### PR TITLE
education pattch

### DIFF
--- a/data/data.ts
+++ b/data/data.ts
@@ -61,7 +61,7 @@ export const academics: Academic[] = [
   {
     institution: "University of Jaffna",
     credential: "B.Sc. Computer Engineering (hons)",
-    period: "Expected 2026",
+    period: "2026",
     details: [
       ` Systems & Infrastructure: Operating Systems, Computer Networking, Computer Architecture, Computer and Network Security.`,
         
@@ -75,7 +75,7 @@ export const academics: Academic[] = [
   {
     institution: "Central College Anuradhapura",
     credential: "G.C.E. Advanced Level",
-    period: "Completed",
+    period: "2020",
     details: [
       "Results: ABB",
       "Subjects: Combined Mathematics, Physics, Chemistry"
@@ -84,7 +84,7 @@ export const academics: Academic[] = [
   {
     institution: "Central College Anuradhapura",
     credential: "G.C.E. Ordinary Level",
-    period: "Completed",
+    period: "2017",
     details: [
       "Results: 9As",
       "Subjects: 6 common subjects, English Literature, Tamil, Information Technology"


### PR DESCRIPTION
This pull request makes minor updates to the academic history data by replacing vague period descriptions with specific years. This improves the clarity and accuracy of the information displayed.

Academic data updates:

* Changed the `period` for the "B.Sc. Computer Engineering (hons)" entry at "University of Jaffna" from "Expected 2026" to "2026".
* Updated the `period` for "G.C.E. Advanced Level" at "Central College Anuradhapura" from "Completed" to "2020".
* Updated the `period` for "G.C.E. Ordinary Level" at "Central College Anuradhapura" from "Completed" to "2017".